### PR TITLE
fix rank order

### DIFF
--- a/neuro_py/process/__init__.pyi
+++ b/neuro_py/process/__init__.pyi
@@ -9,6 +9,7 @@ __all__ = (
     "pairwise_spatial_corr",
     "compute_cross_correlogram",
     "randomize_epochs",
+    "split_epoch_by_width",
     "split_epoch_equal_parts",
     "overlap_intersect",
     "find_intersecting_intervals",
@@ -69,6 +70,7 @@ from .intervals import (
     overlap_intersect,
     randomize_epochs,
     shift_epoch_array,
+    split_epoch_by_width,
     split_epoch_equal_parts,
     truncate_epoch,
 )

--- a/neuro_py/process/intervals.py
+++ b/neuro_py/process/intervals.py
@@ -78,6 +78,35 @@ def randomize_epochs(
     return new_epochs
 
 
+def split_epoch_by_width(
+    intervals: List[Tuple[float, float]], bin_width: float = 0.001
+) -> np.ndarray:
+    """
+    Generate combined intervals (start, stop) at a specified width within given intervals.
+
+    Parameters
+    ----------
+    intervals : List[Tuple[float, float]]
+        A list of (start, end) tuples representing intervals.
+    bin_width : float
+        The width of each bin in seconds. Default is 0.001 (1 ms).
+
+    Returns
+    -------
+    np.ndarray
+        A 2D array containing (start, stop) pairs for all bins across intervals.
+    """
+    bin_intervals = []
+    for start, end in intervals:
+        # Generate bin edges
+        edges = np.arange(start, end, bin_width)
+        edges = np.append(edges, end)  # Ensure the final end is included
+        # Generate intervals (start, stop) for each bin
+        intervals = np.stack((edges[:-1], edges[1:]), axis=1)
+        bin_intervals.append(intervals)
+    return np.vstack(bin_intervals)
+
+
 def split_epoch_equal_parts(
     intervals: np.ndarray, n_parts: int, return_epoch_array: bool = True
 ) -> Union[np.ndarray, nel.EpochArray]:

--- a/neuro_py/process/peri_event.py
+++ b/neuro_py/process/peri_event.py
@@ -7,8 +7,9 @@ from nelpy import EpochArray
 from nelpy.core._eventarray import SpikeTrainArray
 from numba import jit, prange
 from scipy import stats
+from scipy.ndimage import gaussian_filter1d
 from scipy.linalg import toeplitz
-
+from neuro_py.process.intervals import split_epoch_by_width, in_intervals
 
 @jit(nopython=True)
 def crossCorr(
@@ -876,9 +877,10 @@ def get_rank_order(
 
     def rank_order_first_spike(st_epoch, epochs, dt, min_units, ref):
         # set up empty matrix for rank order
-        rank_order = np.ones([st_epoch.data.shape[0], st_epoch.n_intervals]) * np.nan
+        rank_order = np.ones([st_epoch.data.shape[0], epochs.n_intervals]) * np.nan
 
         unit_id = np.arange(st_epoch.data.shape[0])
+        st_epoch._abscissa.support = epochs
 
         # iter over every event
         for event_i, st_temp in enumerate(st_epoch):
@@ -911,24 +913,29 @@ def get_rank_order(
                     rank_order[:, event_i] = np.interp(min_ts, epoch_ts, norm_range)
         return rank_order
 
-    def rank_order_fr(st_epoch, dt, sigma, min_units, ref):
+    def rank_order_fr(st, epochs, dt, sigma, min_units, ref):
         # set up empty matrix for rank order
-        rank_order = np.zeros([st_epoch.data.shape[0], st_epoch.n_intervals]) * np.nan
+        rank_order = np.zeros([st.data.shape[0], epochs.n_intervals]) * np.nan
 
-        unit_id = np.arange(st_epoch.data.shape[0])
+        unit_id = np.arange(st.data.shape[0])
 
-        # bin spike train here (smooth later per epoch to not have edge issues)
-        z_t = st_epoch.bin(ds=dt)
+        edges = split_epoch_by_width(epochs.data, dt)
+
+        z_t = count_in_interval(st.data, edges[:,0], edges[:,1], par_type="counts")
+        _,interval_id = in_intervals(edges[:,0],epochs.data,return_interval=True)
+
         # iter over epochs
-        for event_i, z_t_temp in enumerate(z_t):
+        for event_i, epochs_temp in enumerate(epochs):
             # smooth spike train in order to estimate peak
-            z_t_temp.smooth(sigma=sigma, inplace=True)
-
+            # z_t_temp.smooth(sigma=sigma, inplace=True)
+            z_t_temp = z_t[:,interval_id == event_i]
+            # smooth spike train in order to estimate peak
+            z_t_temp = gaussian_filter1d(z_t_temp, sigma / dt, axis=1)
             if ref == "cells":
                 # find loc of each peak and get sorted idx of active units
-                idx = np.argsort(np.argmax(z_t_temp.data, axis=1))
+                idx = np.argsort(np.argmax(z_t_temp, axis=1))
                 # reorder unit ids by order and remove non-active
-                units = unit_id[idx][np.sum(z_t_temp.data[idx, :] > 0, axis=1) > 0]
+                units = unit_id[idx][np.sum(z_t_temp[idx, :] > 0, axis=1) > 0]
 
                 nUnits = len(units)
 
@@ -941,7 +948,7 @@ def get_rank_order(
                     rank_order[units, event_i] = rank_order[units, event_i] / nUnits
             elif ref == "epoch":
                 # iterate over each cell
-                for cell_i, unit in enumerate(z_t_temp.data):
+                for cell_i, unit in enumerate(z_t_temp):
                     # if the cell is not active apply nan
                     if not np.any(unit > 0):
                         rank_order[cell_i, event_i] = np.nan
@@ -950,18 +957,21 @@ def get_rank_order(
                         rank_order[cell_i, event_i] = np.argmax(unit) / len(unit)
         return rank_order
 
-    # create epoched spike array
-    st_epoch = st[epochs.expand(padding)]
+    # expand epochs by padding amount
+    epochs = epochs.expand(padding)
+
+    # check if there are any spikes in the epoch
+    st_epoch = count_in_interval(st.data, epochs.starts, epochs.stops, par_type="counts")
 
     # if no spikes in epoch, break out
-    if st_epoch.n_active == 0:
+    if (st_epoch == 0).all():
         return np.tile(np.nan, st.data.shape), None
 
     # set up empty matrix for rank order
     if method == "peak_fr":
-        rank_order = rank_order_fr(st_epoch, dt, sigma, min_units, ref)
+        rank_order = rank_order_fr(st, epochs, dt, sigma, min_units, ref)
     elif method == "first_spike":
-        rank_order = rank_order_first_spike(st_epoch, epochs, dt, min_units, ref)
+        rank_order = rank_order_first_spike(st[epochs], epochs, dt, min_units, ref)
     else:
         raise Exception("other method, " + method + " is not implemented")
 

--- a/tests/test_get_rank_order.py
+++ b/tests/test_get_rank_order.py
@@ -1,0 +1,124 @@
+import numpy as np
+import pytest
+from nelpy import EpochArray, SpikeTrainArray
+
+from neuro_py.process.peri_event import get_rank_order
+
+
+# Mock spike train data
+def generate_mock_spike_train(n_cells, n_spikes, duration):
+    """
+    Generate mock spike train data for testing.
+    """
+    spike_times = [
+        np.sort(np.random.uniform(0, duration, size=n_spikes)) for _ in range(n_cells)
+    ]
+    return SpikeTrainArray(spike_times, fs=20_000)
+
+
+# Mock epoch array data
+def generate_mock_epochs(n_epochs, duration, epoch_length):
+    """
+    Generate mock epochs for testing.
+    """
+    starts = np.arange(0, n_epochs * duration, duration)
+    stops = starts + epoch_length
+    return EpochArray(np.vstack((starts, stops)).T)
+
+
+def test_get_rank_order_first_spike_cells():
+    st = generate_mock_spike_train(n_cells=10, n_spikes=20, duration=10)
+    epochs = generate_mock_epochs(n_epochs=5, duration=2, epoch_length=1)
+
+    median_rank, rank_order = get_rank_order(
+        st, epochs, method="first_spike", ref="cells", padding=0.1
+    )
+
+    assert median_rank.shape == (10,)
+    assert rank_order.shape == (10, 5)
+    # Replace NaNs with 0 for easier comparison
+    rank_order[np.isnan(rank_order)] = 0
+    assert np.all((0 <= rank_order) & (rank_order <= 1))  # Normalized rank orders
+
+
+def test_get_rank_order_first_spike_epoch():
+    st = generate_mock_spike_train(n_cells=10, n_spikes=20, duration=10)
+    epochs = generate_mock_epochs(n_epochs=5, duration=2, epoch_length=1)
+
+    median_rank, rank_order = get_rank_order(
+        st, epochs, method="first_spike", ref="epoch", padding=0.1
+    )
+
+    assert median_rank.shape == (10,)
+    assert rank_order.shape == (10, 5)
+    # Replace NaNs with 0 for easier comparison
+    rank_order[np.isnan(rank_order)] = 0
+    assert np.all((0 <= rank_order) & (rank_order <= 1))  # Normalized rank orders
+
+
+def test_get_rank_order_peak_fr_cells():
+    st = generate_mock_spike_train(n_cells=10, n_spikes=50, duration=10)
+    epochs = generate_mock_epochs(n_epochs=5, duration=2, epoch_length=1)
+
+    median_rank, rank_order = get_rank_order(
+        st, epochs, method="peak_fr", ref="cells", dt=0.001, sigma=0.01, padding=0.1
+    )
+
+    assert median_rank.shape == (10,)
+    assert rank_order.shape == (10, 5)
+    # Replace NaNs with 0 for easier comparison
+    rank_order[np.isnan(rank_order)] = 0
+    assert np.all((0 <= rank_order) & (rank_order <= 1))  # Normalized rank orders
+
+
+def test_get_rank_order_peak_fr_epoch():
+    st = generate_mock_spike_train(n_cells=10, n_spikes=50, duration=10)
+    epochs = generate_mock_epochs(n_epochs=5, duration=2, epoch_length=1)
+
+    median_rank, rank_order = get_rank_order(
+        st, epochs, method="peak_fr", ref="epoch", dt=0.001, sigma=0.01, padding=0.1
+    )
+
+    assert median_rank.shape == (10,)
+    assert rank_order.shape == (10, 5)
+    # Replace NaNs with 0 for easier comparison
+    rank_order[np.isnan(rank_order)] = 0
+    assert np.all((0 <= rank_order) & (rank_order <= 1))  # Normalized rank orders
+
+
+def test_get_rank_order_empty_spike_train():
+    st = SpikeTrainArray([[] for _ in range(10)])  # 10 cells, no spikes
+    epochs = generate_mock_epochs(n_epochs=5, duration=2, epoch_length=1)
+
+    median_rank, rank_order = get_rank_order(
+        st, epochs, method="first_spike", ref="cells"
+    )
+
+    assert np.all(np.isnan(median_rank))
+    assert np.all(np.isnan(rank_order))
+
+
+def test_get_rank_order_no_spikes_in_epochs():
+    st = generate_mock_spike_train(n_cells=10, n_spikes=20, duration=10)
+    epochs = EpochArray([[20, 22]])  # No spikes fall within this range
+
+    median_rank, rank_order = get_rank_order(st, epochs, method="peak_fr", ref="epoch")
+
+    assert np.all(np.isnan(median_rank))
+    assert np.all(np.isnan(rank_order))
+
+
+def test_get_rank_order_invalid_method():
+    st = generate_mock_spike_train(n_cells=10, n_spikes=20, duration=10)
+    epochs = generate_mock_epochs(n_epochs=5, duration=2, epoch_length=1)
+
+    with pytest.raises(Exception, match="method random_method not implemented"):
+        get_rank_order(st, epochs, method="random_method", ref="cells")
+
+
+def test_get_rank_order_invalid_reference():
+    st = generate_mock_spike_train(n_cells=10, n_spikes=20, duration=10)
+    epochs = generate_mock_epochs(n_epochs=5, duration=2, epoch_length=1)
+
+    with pytest.raises(Exception, match="ref random_ref not implemented"):
+        get_rank_order(st, epochs, method="first_spike", ref="random_ref")

--- a/tests/test_get_rank_order.py
+++ b/tests/test_get_rank_order.py
@@ -122,3 +122,73 @@ def test_get_rank_order_invalid_reference():
 
     with pytest.raises(Exception, match="ref random_ref not implemented"):
         get_rank_order(st, epochs, method="first_spike", ref="random_ref")
+
+
+def test_get_rank_order_explicit_spike_times():
+    # Explicit spike times for predictable rank order
+    # Cell 0 spikes first, Cell 1 second, etc.
+    spike_times = [
+        np.array([0.1]),  # Cell 0 spikes first
+        np.array([0.2]),  # Cell 1 spikes second
+        np.array([0.3]),  # Cell 2 spikes third
+        np.array([0.4]),  # Cell 3 spikes fourth
+        np.array([0.5]),  # Cell 4 spikes fifth
+    ]
+    st = SpikeTrainArray(spike_times)
+
+    # One epoch covering all spike times
+    epochs = EpochArray(np.array([[0, 1]]))  # From 0 to 1 second
+
+    # Expected rank order: cells are ranked based on their spike times
+    expected_rank_order_cells = np.array(
+        [
+            [0.0],  # Cell 0 has rank 0 (earliest spike)
+            [0.2],  # Cell 1
+            [0.4],  # Cell 2
+            [0.6],  # Cell 3
+            [0.8],  # Cell 4 has rank 1 (latest spike)
+        ]
+    )
+
+    # Test the 'first_spike' method with 'cells' reference
+    median_rank, rank_order = get_rank_order(
+        st, epochs, method="first_spike", ref="cells", padding=0, dt=0.001
+    )
+
+    # Check shapes
+    assert median_rank.shape == (5,)
+    assert rank_order.shape == (5, 1)
+
+    # Check rank order values
+    np.testing.assert_almost_equal(rank_order, expected_rank_order_cells, decimal=3)
+    np.testing.assert_almost_equal(
+        median_rank, np.nanmedian(expected_rank_order_cells, axis=1), decimal=3
+    )
+
+    # Test the 'first_spike' method with 'epoch' reference
+    # For 'epoch' reference, rank should be normalized to the epoch (0-1)
+    expected_rank_order_epoch = np.array(
+        [
+            [0.1],  # Cell 0 spikes at 0.1 in a 0-1 interval
+            [0.2],  # Cell 1
+            [0.3],  # Cell 2
+            [0.4],  # Cell 3
+            [0.5],  # Cell 4
+        ]
+    )
+
+    median_rank_epoch, rank_order_epoch = get_rank_order(
+        st, epochs, method="first_spike", ref="epoch", padding=0, dt=0.001
+    )
+
+    # Check shapes
+    assert median_rank_epoch.shape == (5,)
+    assert rank_order_epoch.shape == (5, 1)
+
+    # Check rank order values
+    np.testing.assert_almost_equal(
+        rank_order_epoch, expected_rank_order_epoch, decimal=3
+    )
+    np.testing.assert_almost_equal(
+        median_rank_epoch, np.nanmedian(expected_rank_order_epoch, axis=1), decimal=3
+    )


### PR DESCRIPTION
because nelpy merges epochs, rank order may return fewer than input. The fix here was to change support after restricting and also bypassing the use of spike train array