### PR TITLE
fixed bug in get_weights when patterns is None

### DIFF
--- a/neuro_py/ensemble/assembly_reactivation.py
+++ b/neuro_py/ensemble/assembly_reactivation.py
@@ -264,6 +264,7 @@ class AssemblyReact:
 
         if (bst == 0).all():
             self.patterns = None
+            return
         else:
             patterns, _, _ = assembly.runPatterns(
                 bst,
@@ -274,6 +275,11 @@ class AssemblyReact:
                 tracywidom=self.tracywidom,
                 whiten=self.whiten,
             )
+
+            if patterns is None: 
+                self.patterns = None
+                return 
+            
             # flip patterns to have positive max
             self.patterns = np.array(
                 [


### PR DESCRIPTION
runPatterns returns patterns as None when there are no assemblies, no significant assemblies or significant assemblies is nan. 

get_weights failed when the above happened. Added line to detect if patterns is None return self.patterns = None 