### PR TITLE
remove verbose False CyclicLR

### DIFF
--- a/neuro_py/ensemble/decoding/mlp.py
+++ b/neuro_py/ensemble/decoding/mlp.py
@@ -235,7 +235,6 @@ class MLP(L.LightningModule):
             mode='triangular2',
             gamma=0.99994,
             last_epoch=-1,
-            verbose=False
         )
         lr_scheduler = {'scheduler': scheduler, 'interval': 'step'}
         return [optimizer], [lr_scheduler]


### PR DESCRIPTION
Versioning issue: TypeError: CyclicLR.__init__() got an unexpected keyword argument 'verbose'