### PR TITLE
[codex] Update shared agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,8 @@ Repo docs:
 - Prefer local, targeted edits over broad refactors.
 - If a change affects behavior, add or update a regression test in the matching `tests/<module>/` area.
 - Do not widen scope because you notice unrelated issues.
+- Keep scientific behavior stable unless the task explicitly calls for an algorithmic change.
+- When behavior must change, describe the old vs new behavior clearly in code comments, tests, or the PR summary.
 
 ## Repo Conventions
 
@@ -24,6 +26,27 @@ Repo docs:
 - Use `nelpy` objects for time series and ephys data when the API expects them.
 - Use `EpochArray` indexing instead of manual boolean masking when restricting to epochs.
 - When editing `neuro_py/io/loading.py`, also follow the loader-specific rules in `.github/instructions/io-loading.instructions.md`.
+- Preserve existing return types and shape conventions unless the task explicitly requires a change.
+- Prefer column names and outputs that match existing conventions such as `start`, `stop`, `peaks`, `center`, `duration`, `startTime`, and `stopTime`.
+- Treat timestamps, sampling rates, and array orientation as part of the public behavior. Be explicit about whether data is `(n_samples, n_channels)` or `(n_channels, n_samples)`.
+- Prefer warning-and-empty-result behavior over hard failure when a loader is missing an expected file, unless nearby loaders already establish a stricter contract.
+- Avoid hidden unit changes. If a function works in seconds, samples, Hz, radians, or channel indices, keep that contract explicit.
+
+## Scientific Guardrails
+
+- Preserve numerical intent before chasing cleanup. Small-looking changes to indexing, smoothing, thresholds, interpolation, or event windows can change scientific results.
+- Be careful with inclusive vs exclusive interval boundaries and off-by-one sample behavior.
+- Preserve NaN handling when possible. Do not silently coerce missing data to zeros.
+- Keep channel numbering and shank/group conventions aligned with the surrounding code and tests.
+- When restricting data to epochs or supports, prefer the existing `nelpy`-based pathway used by nearby code.
+- For behavior and LFP code, be cautious about timestamp alignment, sample counts, and whether derived arrays must stay the same length as the input signal.
+
+## Performance
+
+- Prefer vectorized NumPy or pandas operations over Python loops for sample-wise work.
+- Avoid unnecessary materialization or copying of large arrays, memmaps, or lazy loader views.
+- Preserve lazy-loading behavior unless the task explicitly requires eager loading.
+- In loader code, avoid reading full binary files into memory when an existing memmap or view-based approach already works.
 
 ## Standard Imports
 
@@ -62,6 +85,7 @@ neuro_py/
 - Pytest is the test runner.
 - Write tests in pytest style; avoid `unittest.TestCase` and `unittest` assertion helpers.
 - Python support starts at 3.10.
+- CI runs `ruff check .` and `pytest` on Python 3.10, 3.11, 3.12, and 3.13.
 
 Before finishing a change, run the narrowest relevant test subset first, then broader tests if needed. If you cannot run tests in the current environment, say so explicitly.
 
@@ -101,6 +125,33 @@ def load_spikes(basepath: str, putativeCellType: list | None = None) -> nel.Spik
 - Put tests in the matching module folder under `tests/`.
 - Name tests after the behavior they cover, not the implementation detail.
 - Add edge-case coverage when a bug fix changes control flow or input validation.
+- Prefer realistic small fixtures over heavy mocks when shape, timestamps, or `nelpy` behavior matter.
+- Assert behavior that users rely on: output types, array shapes, column names, warning behavior, and numerical sanity.
+
+Common module-to-test mappings:
+
+- `neuro_py/behavior/*` -> `tests/behavior/`
+- `neuro_py/detectors/*` -> `tests/detectors/`
+- `neuro_py/ensemble/*` -> `tests/ensemble/`
+- `neuro_py/ensemble/decoding/*` -> `tests/ensemble/decoding/`
+- `neuro_py/io/loading.py` -> `tests/test_io/test_loading.py`
+- `neuro_py/lfp/*` -> `tests/lfp/`
+- `neuro_py/plotting/*` -> `tests/plotting/`
+- `neuro_py/process/*` -> `tests/process/`
+- `neuro_py/raw/*` -> `tests/raw/`
+- `neuro_py/session/*` -> `tests/session/`
+- `neuro_py/spikes/*` -> `tests/spikes/`
+- `neuro_py/stats/*` -> `tests/stats/`
+- `neuro_py/tuning/*` -> `tests/tuning/`
+- `neuro_py/util/*` -> `tests/util/`
+
+Useful targeted test commands:
+
+- `pytest tests/test_io/test_loading.py`
+- `pytest tests/process`
+- `pytest tests/lfp`
+- `pytest tests/behavior`
+- `pytest tests/ensemble`
 
 ## What Not to Do
 
@@ -109,6 +160,17 @@ def load_spikes(basepath: str, putativeCellType: list | None = None) -> nel.Spik
 - Do not introduce mutable default arguments.
 - Do not skip tests for behavior changes.
 - Do not expand a fix into unrelated cleanup.
+- Do not silently change output orientation, units, or return types.
+- Do not replace warnings with exceptions, or exceptions with warnings, unless nearby code and tests support the change.
+- Do not densify large lazy arrays just to satisfy a small indexing or shape check.
+- Do not “fix” failing scientific outputs by loosening assertions without understanding the numerical contract.
+
+## Change Strategy
+
+- For loaders and preprocessing, prioritize compatibility with messy real datasets: missing files, incomplete metadata, scalar-vs-vector MATLAB fields, NaNs, and mixed session layouts.
+- For plotting utilities, preserve defaults and return values that downstream notebooks may rely on.
+- For numerical routines, prefer a narrowly scoped regression test that captures the bug with a compact synthetic example.
+- For public APIs, use deprecation-style changes only when necessary: keep old behavior working when feasible, and update tests/docstrings to explain the transition.
 
 ## Reference
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,8 @@
-# neuro_py Copilot Instructions
+# neuro_py Agent Instructions
 
 neuro_py is a Python package for analysis of freely moving neuroelectrophysiology data, built on top of nelpy for core data objects.
+
+These instructions are written to be useful for GitHub Copilot, Codex, and similar coding agents. Keep the guidance implementation-focused and repo-specific rather than tied to one tool's UI or workflow.
 
 Repo docs:
 - API: https://ryanharvey1.github.io/neuro_py/reference/
@@ -21,7 +23,7 @@ Repo docs:
 - Keep imports in the usual order: stdlib, third-party, then project imports.
 - Use `nelpy` objects for time series and ephys data when the API expects them.
 - Use `EpochArray` indexing instead of manual boolean masking when restricting to epochs.
-- Loader-specific rules live in `.github/instructions/io-loading.instructions.md`.
+- When editing `neuro_py/io/loading.py`, also follow the loader-specific rules in `.github/instructions/io-loading.instructions.md`.
 
 ## Standard Imports
 
@@ -61,7 +63,7 @@ neuro_py/
 - Write tests in pytest style; avoid `unittest.TestCase` and `unittest` assertion helpers.
 - Python support starts at 3.10.
 
-Before finishing a change, run the narrowest relevant test subset first, then broader tests if needed.
+Before finishing a change, run the narrowest relevant test subset first, then broader tests if needed. If you cannot run tests in the current environment, say so explicitly.
 
 ## Docstrings
 

--- a/.github/instructions/io-loading.instructions.md
+++ b/.github/instructions/io-loading.instructions.md
@@ -15,3 +15,8 @@ When editing loaders in `io/loading.py`:
 - `LFPLoader` should preserve the parent `nel.AnalogSignalArray` interface.
 - `loadLFP` is a low-level helper that returns raw `(data, timestamps)`.
 - Keep missing-data handling aligned with the nearest loader in the same module.
+- Preserve existing output orientation and laziness in `loadLFP`; be explicit about whether arrays are `(n_samples, n_channels)` or channel-selected 1-D outputs.
+- Preserve Windows-safe memmap handling and explicit cleanup patterns when touching binary file loading.
+- Support both concatenated session files and per-epoch fallback layouts when working on DAT/LFP loading paths.
+- Prefer compact synthetic fixtures in `tests/test_io/test_loading.py` that assert types, shapes, timestamps, warnings, and fallback behavior.
+- When parsing MATLAB structs, handle scalar fields, optional keys, and inconsistent field shapes defensively rather than assuming one exact layout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,6 @@ Working rules for Codex:
 - Add or update a regression test in the matching `tests/` area when behavior changes.
 - Use type hints on function signatures and numpydoc docstrings for public functions.
 - Run the narrowest relevant pytest target you can before finishing, and clearly report if you could not run tests.
+- Preserve scientific behavior, units, shapes, and `nelpy` semantics unless the task explicitly requires a change.
+- For loader work, follow `.github/instructions/io-loading.instructions.md` and keep missing-data behavior aligned with nearby loaders.
+- Prefer vectorized changes and avoid unnecessarily materializing large arrays or lazy loader views.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# neuro_py Agent Guide
+
+Use this file as the Codex entry point for repository-specific instructions.
+
+Primary guidance lives in [.github/copilot-instructions.md](.github/copilot-instructions.md). Those instructions are intentionally written to work for GitHub Copilot, Codex, and similar coding agents.
+
+Additional scoped guidance:
+
+- When editing `neuro_py/io/loading.py`, also follow `.github/instructions/io-loading.instructions.md`.
+
+Working rules for Codex:
+
+- Prefer the smallest targeted change that fixes the root cause.
+- Preserve public APIs unless the task explicitly requires a breaking change.
+- Add or update a regression test in the matching `tests/` area when behavior changes.
+- Use type hints on function signatures and numpydoc docstrings for public functions.
+- Run the narrowest relevant pytest target you can before finishing, and clearly report if you could not run tests.


### PR DESCRIPTION
## Summary
- make the shared `.github` instructions explicitly agent-agnostic so they stay useful for both GitHub Copilot and Codex
- add a lightweight `AGENTS.md` entry point for Codex that points back to the same instruction source
- clarify the scoped loader rule and the expectation to report when tests could not be run

## Why
The repository already had solid Copilot guidance, but Codex benefits from a standard repo-level `AGENTS.md` entry point. This keeps one primary instruction source instead of duplicating or diverging rules across tools.

## Validation
- No tests run because this change only updates repository instruction files.