### PR TITLE
Add root object HDF5 support for batch analysis

### DIFF
--- a/neuro_py/process/batch_analysis.py
+++ b/neuro_py/process/batch_analysis.py
@@ -12,6 +12,10 @@ import pandas as pd
 from joblib import Parallel, delayed
 from tqdm import tqdm
 
+_HDF5_ROOT_OBJECT_KEY = "root_object"
+_HDF5_ROOT_TYPE_ATTR = "root_type"
+_HDF5_ROOT_TYPE_OBJECT = "object"
+
 
 def encode_file_path(basepath: str, save_path: str, format_type: str = "pickle") -> str:
     """
@@ -214,14 +218,14 @@ def _load_inhomogeneous_data_hdf5(group: h5py.Group, key: str) -> object:
         raise KeyError(f"Inhomogeneous data with key '{key}' not found")
 
 
-def _save_to_hdf5(data: Union[pd.DataFrame, dict], filepath: str) -> None:
+def _save_to_hdf5(data: object, filepath: str) -> None:
     """
-    Save data to HDF5 format with support for inhomogeneous arrays.
+    Save data to HDF5 format with support for mixed Python objects.
 
     Parameters
     ----------
-    data : Union[pd.DataFrame, dict]
-        Data to save. Can be a DataFrame or dict containing DataFrames/arrays.
+    data : object
+        Data to save. Can be a DataFrame, a dict, or a picklable Python object.
     filepath : str
         Path to save the HDF5 file.
     """
@@ -263,6 +267,9 @@ def _save_to_hdf5(data: Union[pd.DataFrame, dict], filepath: str) -> None:
                         print(
                             f"Warning: Saved {key} as string representation due to: {e}"
                         )
+        else:
+            _save_inhomogeneous_data_hdf5(f, _HDF5_ROOT_OBJECT_KEY, data)
+            f.attrs[_HDF5_ROOT_TYPE_ATTR] = _HDF5_ROOT_TYPE_OBJECT
 
 
 def _save_dataframe_to_hdf5(
@@ -337,9 +344,9 @@ def _save_dataframe_to_hdf5(
     ]  # Type info
 
 
-def _load_from_hdf5(filepath: str) -> Union[pd.DataFrame, dict]:
+def _load_from_hdf5(filepath: str) -> Union[pd.DataFrame, dict, object]:
     """
-    Load data from HDF5 format with support for inhomogeneous arrays.
+    Load data from HDF5 format with support for mixed Python objects.
 
     Parameters
     ----------
@@ -348,10 +355,13 @@ def _load_from_hdf5(filepath: str) -> Union[pd.DataFrame, dict]:
 
     Returns
     -------
-    Union[pd.DataFrame, dict]
+    Union[pd.DataFrame, dict, object]
         Loaded data.
     """
     with h5py.File(filepath, "r") as f:
+        if f.attrs.get(_HDF5_ROOT_TYPE_ATTR, "") == _HDF5_ROOT_TYPE_OBJECT:
+            return _load_inhomogeneous_data_hdf5(f, _HDF5_ROOT_OBJECT_KEY)
+
         if "dataframe" in f and len(f.keys()) == 1:
             # Single DataFrame case
             return _load_dataframe_from_hdf5(f["dataframe"])
@@ -801,7 +811,7 @@ def load_results(
 
 def load_specific_data(
     filepath: Union[str, os.PathLike], key: Optional[str] = None
-) -> Union[pd.DataFrame, dict, np.ndarray, None]:
+) -> Union[pd.DataFrame, dict, np.ndarray, object, None]:
     """
     Load specific data from a file (supports selective loading for HDF5).
 
@@ -814,7 +824,7 @@ def load_specific_data(
 
     Returns
     -------
-    Union[pd.DataFrame, dict, np.ndarray, None]
+    Union[pd.DataFrame, dict, np.ndarray, object, None]
         Loaded data, or None if key not found in file.
     """
     filepath_str = str(filepath)
@@ -824,11 +834,14 @@ def load_specific_data(
             return _load_from_hdf5(filepath_str)
         else:
             with h5py.File(filepath_str, "r") as f:
+                if f.attrs.get(_HDF5_ROOT_TYPE_ATTR, "") == _HDF5_ROOT_TYPE_OBJECT:
+                    return None
                 if key in f:
                     if isinstance(f[key], h5py.Group):
                         return _load_dataframe_from_hdf5(f[key])
                     else:
-                        return f[key][:]
+                        dataset = f[key]
+                        return dataset[()] if dataset.shape == () else dataset[:]
                 elif f"{key}_inhomogeneous" in f or f"{key}_pickled" in f:
                     return _load_inhomogeneous_data_hdf5(f, key)
                 else:

--- a/neuro_py/process/batch_analysis.py
+++ b/neuro_py/process/batch_analysis.py
@@ -344,7 +344,7 @@ def _save_dataframe_to_hdf5(
     ]  # Type info
 
 
-def _load_from_hdf5(filepath: str) -> Union[pd.DataFrame, dict, object]:
+def _load_from_hdf5(filepath: str) -> object:
     """
     Load data from HDF5 format with support for mixed Python objects.
 
@@ -355,8 +355,9 @@ def _load_from_hdf5(filepath: str) -> Union[pd.DataFrame, dict, object]:
 
     Returns
     -------
-    Union[pd.DataFrame, dict, object]
-        Loaded data.
+    object
+        Loaded data. Returns a pandas DataFrame, a dictionary of saved values,
+        or a root-level object saved through the pickle-backed fallback path.
     """
     with h5py.File(filepath, "r") as f:
         if f.attrs.get(_HDF5_ROOT_TYPE_ATTR, "") == _HDF5_ROOT_TYPE_OBJECT:
@@ -815,7 +816,7 @@ def load_results(
 
 def load_specific_data(
     filepath: Union[str, os.PathLike], key: Optional[str] = None
-) -> Union[pd.DataFrame, dict, np.ndarray, object, None]:
+) -> Optional[object]:
     """
     Load specific data from a file (supports selective loading for HDF5).
 
@@ -828,7 +829,7 @@ def load_specific_data(
 
     Returns
     -------
-    Union[pd.DataFrame, dict, np.ndarray, object, None]
+    object or None
         Loaded data, or None if key not found in file.
     """
     filepath_str = str(filepath)

--- a/neuro_py/process/batch_analysis.py
+++ b/neuro_py/process/batch_analysis.py
@@ -362,7 +362,11 @@ def _load_from_hdf5(filepath: str) -> Union[pd.DataFrame, dict, object]:
         if f.attrs.get(_HDF5_ROOT_TYPE_ATTR, "") == _HDF5_ROOT_TYPE_OBJECT:
             return _load_inhomogeneous_data_hdf5(f, _HDF5_ROOT_OBJECT_KEY)
 
-        if "dataframe" in f and len(f.keys()) == 1:
+        non_internal_attrs = {
+            key: value for key, value in f.attrs.items() if key != _HDF5_ROOT_TYPE_ATTR
+        }
+
+        if "dataframe" in f and len(f.keys()) == 1 and len(non_internal_attrs) == 0:
             # Single DataFrame case
             return _load_dataframe_from_hdf5(f["dataframe"])
         else:

--- a/neuro_py/process/batch_analysis.py
+++ b/neuro_py/process/batch_analysis.py
@@ -12,8 +12,8 @@ import pandas as pd
 from joblib import Parallel, delayed
 from tqdm import tqdm
 
-_HDF5_ROOT_OBJECT_KEY = "root_object"
-_HDF5_ROOT_TYPE_ATTR = "root_type"
+_HDF5_ROOT_OBJECT_KEY = "__neuro_py_root_object__"
+_HDF5_ROOT_TYPE_ATTR = "__neuro_py_root_payload_type__"
 _HDF5_ROOT_TYPE_OBJECT = "object"
 
 

--- a/tests/detectors/test_up_down_state.py
+++ b/tests/detectors/test_up_down_state.py
@@ -143,9 +143,9 @@ def test_detect_up_down_states_bimodal_thresh_basic():
         t = 0
         bin_size = 0.01
         for rate in firing_rate_series:
-            n_spikes = np.random.poisson(rate * bin_size)
+            n_spikes = rng.poisson(rate * bin_size)
             if n_spikes > 0:
-                spike_times.extend(np.random.uniform(t, t + bin_size, n_spikes))
+                spike_times.extend(rng.uniform(t, t + bin_size, n_spikes))
             t += bin_size
         spikes_list.append(np.sort(spike_times))
 
@@ -200,9 +200,9 @@ def test_detect_up_down_states_bimodal_thresh_epoch_by_epoch():
         bin_size = 0.01
         all_rates = np.concatenate([epoch1_rates, epoch2_rates])
         for rate in all_rates:
-            n_spikes = np.random.poisson(rate * bin_size)
+            n_spikes = rng.poisson(rate * bin_size)
             if n_spikes > 0:
-                spike_times.extend(np.random.uniform(t, t + bin_size, n_spikes))
+                spike_times.extend(rng.uniform(t, t + bin_size, n_spikes))
             t += bin_size
         spikes_list.append(np.sort(spike_times))
 

--- a/tests/process/test_batch_analysis.py
+++ b/tests/process/test_batch_analysis.py
@@ -466,6 +466,20 @@ class TestRootObjectHDF5:
         assert loaded_via_specific == data
         assert load_specific_data(filepath, key="anything") is None
 
+    def test_dict_payload_with_root_type_key_hdf5(self, tmp_path):
+        """Test dict payloads can safely use keys that resemble internal markers."""
+        data = {
+            "root_type": "object",
+            "dataframe": pd.DataFrame({"col1": [1, 2, 3]}),
+        }
+        filepath = tmp_path / "dict_with_root_type.h5"
+
+        _save_to_hdf5(data, filepath)
+        loaded_data = _load_from_hdf5(filepath)
+
+        assert loaded_data["root_type"] == "object"
+        pd.testing.assert_frame_equal(loaded_data["dataframe"], data["dataframe"])
+
     def test_save_load_top_level_nelpy_object_hdf5(self, tmp_path):
         """Test saving and loading a top-level nelpy object."""
         nel = pytest.importorskip("nelpy")

--- a/tests/process/test_batch_analysis.py
+++ b/tests/process/test_batch_analysis.py
@@ -480,6 +480,55 @@ class TestRootObjectHDF5:
         assert loaded_data["root_type"] == "object"
         pd.testing.assert_frame_equal(loaded_data["dataframe"], data["dataframe"])
 
+    def test_load_specific_data_preserves_dict_with_dataframe_key_hdf5(self, tmp_path):
+        """Test whole-file loads preserve dict payloads with DataFrame members."""
+        data = {
+            "root_type": "object",
+            "scalar_int": 7,
+            "dataframe": pd.DataFrame({"col1": [1, 2, 3]}),
+        }
+        filepath = tmp_path / "dict_payload.h5"
+
+        _save_to_hdf5(data, filepath)
+
+        loaded_data = load_specific_data(filepath)
+        assert isinstance(loaded_data, dict)
+        assert loaded_data["root_type"] == "object"
+        assert loaded_data["scalar_int"] == 7
+        pd.testing.assert_frame_equal(loaded_data["dataframe"], data["dataframe"])
+
+    def test_load_specific_data_keyed_dataframe_from_mixed_dict_hdf5(self, tmp_path):
+        """Test keyed HDF5 loads still return the DataFrame member from mixed dicts."""
+        data = {
+            "root_type": "object",
+            "dataframe": pd.DataFrame({"col1": [1, 2, 3]}),
+        }
+        filepath = tmp_path / "mixed_dict_dataframe.h5"
+
+        _save_to_hdf5(data, filepath)
+
+        loaded_dataframe = load_specific_data(filepath, key="dataframe")
+        pd.testing.assert_frame_equal(loaded_dataframe, data["dataframe"])
+
+    def test_load_results_hdf5_extracts_dataframe_from_mixed_dict(self, tmp_path):
+        """Test load_results still extracts the DataFrame from mixed HDF5 dict payloads."""
+        save_path = str(tmp_path)
+        data = {
+            "dataframe": pd.DataFrame({"session": ["session1"], "value": [1]}),
+            "root_type": "object",
+            "scalar_int": 7,
+        }
+        filepath = tmp_path / "results.h5"
+
+        _save_to_hdf5(data, filepath)
+
+        results = load_results(save_path, format_type="hdf5")
+
+        assert isinstance(results, pd.DataFrame)
+        assert len(results) == 1
+        assert results["session"].iloc[0] == "session1"
+        assert results["value"].iloc[0] == 1
+
     def test_save_load_top_level_nelpy_object_hdf5(self, tmp_path):
         """Test saving and loading a top-level nelpy object."""
         nel = pytest.importorskip("nelpy")

--- a/tests/process/test_batch_analysis.py
+++ b/tests/process/test_batch_analysis.py
@@ -449,6 +449,60 @@ class TestHDF5MixedDataOperations:
         pd.testing.assert_frame_equal(df, loaded_df)
 
 
+class TestRootObjectHDF5:
+    """Test HDF5 operations for top-level non-dict objects."""
+
+    def test_save_load_top_level_tuple_hdf5(self, tmp_path):
+        """Test saving and loading a top-level tuple."""
+        data = (1, "two", 3.0)
+        filepath = tmp_path / "tuple_root.h5"
+
+        _save_to_hdf5(data, filepath)
+
+        loaded_data = _load_from_hdf5(filepath)
+        assert loaded_data == data
+
+        loaded_via_specific = load_specific_data(filepath)
+        assert loaded_via_specific == data
+        assert load_specific_data(filepath, key="anything") is None
+
+    def test_save_load_top_level_nelpy_object_hdf5(self, tmp_path):
+        """Test saving and loading a top-level nelpy object."""
+        nel = pytest.importorskip("nelpy")
+        data = nel.EpochArray([[0.0, 1.0], [2.0, 3.5]])
+        filepath = tmp_path / "epoch_root.h5"
+
+        _save_to_hdf5(data, filepath)
+        loaded_data = _load_from_hdf5(filepath)
+
+        assert isinstance(loaded_data, nel.EpochArray)
+        np.testing.assert_allclose(loaded_data.data, data.data)
+
+        loaded_via_specific = load_specific_data(filepath)
+        assert isinstance(loaded_via_specific, nel.EpochArray)
+        np.testing.assert_allclose(loaded_via_specific.data, data.data)
+        assert load_specific_data(filepath, key="anything") is None
+
+    def test_main_loop_hdf5_top_level_object(self, tmp_path):
+        """Test main_loop can persist a top-level object with HDF5."""
+        nel = pytest.importorskip("nelpy")
+
+        def dummy_func(basepath):
+            return nel.EpochArray([[0.0, 1.0], [2.0, 3.5]])
+
+        basepath = "test_session"
+        save_path = str(tmp_path)
+
+        main_loop(basepath, save_path, dummy_func, format_type="hdf5")
+
+        expected_file = encode_file_path(basepath, save_path, "hdf5")
+        assert os.path.exists(expected_file)
+
+        result = _load_from_hdf5(expected_file)
+        assert isinstance(result, nel.EpochArray)
+        np.testing.assert_allclose(result.data, np.array([[0.0, 1.0], [2.0, 3.5]]))
+
+
 class TestMainLoop:
     """Test main_loop function."""
 


### PR DESCRIPTION
## Summary

Add HDF5 support for top-level non-dict batch-analysis results, including `nelpy` objects, by storing arbitrary root objects through the existing pickle-backed fallback path.

## What Changed

- broadened `_save_to_hdf5` to accept generic top-level objects
- added a reserved root-object marker so `_load_from_hdf5` can distinguish object files from existing DataFrame/dict layouts
- updated `load_specific_data` so full-file loads return the raw root object and keyed lookups return `None` for root-object files
- added regression coverage for:
  - top-level tuple HDF5 round trips
  - top-level `nelpy.EpochArray` HDF5 round trips
  - `main_loop(..., format_type="hdf5")` saving a top-level `nelpy` object

## Why

Previously, HDF5 batch saves only handled top-level `DataFrame` and `dict` payloads. If an analysis function returned a single object like a `nelpy` object directly, it would not be saved unless the caller manually wrapped it in a dict first.

## Validation

- added focused regression tests in `tests/process/test_batch_analysis.py`
- attempted to run `pytest tests/process/test_batch_analysis.py`
- local test collection is currently blocked by an environment incompatibility in the installed stack: `h5py` import fails against the available NumPy version with `AttributeError: module 'numpy' has no attribute 'typeDict'`
