### PR TITLE
[codex] Hide private docs members

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,9 +76,10 @@ plugins:
             docstring_style: numpy
             docstring_section_style: table
             filters:
-              - "!__"
-              - "!tests"
-              - "!test_*"
+              - "!^__"
+              - "!^_[^_]"
+              - "!^test_"
+              - "!^tests$"
 nav:
 - Home: index.md
 - API Reference:
@@ -97,6 +98,7 @@ nav:
   - detectors:
     - detectors: reference/neuro_py/detectors/index.md
     - dentate_spike: reference/neuro_py/detectors/dentate_spike.md
+    - sharp_wave_ripple: reference/neuro_py/detectors/sharp_wave_ripple.md
     - up_down_state: reference/neuro_py/detectors/up_down_state.md
   - ensemble:
     - ensemble: reference/neuro_py/ensemble/index.md
@@ -132,6 +134,7 @@ nav:
     - decorators: reference/neuro_py/plotting/decorators.md
     - events: reference/neuro_py/plotting/events.md
     - figure_helpers: reference/neuro_py/plotting/figure_helpers.md
+    - replay: reference/neuro_py/plotting/replay.md
   - process:
     - process: reference/neuro_py/process/index.md
     - batch_analysis: reference/neuro_py/process/batch_analysis.md


### PR DESCRIPTION
## Summary
- Restore mkdocstrings filtering for private single-underscore members and add explicit double-underscore filtering.
- Add missing API nav entries for `detectors/sharp_wave_ripple` and `plotting/replay`.

## Why
Private helper functions such as `_zscore` were appearing in generated API docs because the custom mkdocstrings filter list overrode the default private-member filter. Some generated reference pages also existed but were missing from the API Reference dropdown nav.

## Validation
- Ran `uv run --extra docs zensical build` successfully.
- Verified private helper anchors are not rendered for the sharp-wave-ripple and double-underscore helper cases.
- Verified public API entries such as `detect_sharp_wave_ripples`, `save_ripple_events`, and `VirtualConcatenatedDatView` still render.
- Verified generated dropdown nav includes `sharp_wave_ripple` and `plotting/replay`.