### PR TITLE
[codex] Contain wide notebook dataframes

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -73,3 +73,17 @@
 .md-header .md-search__button::after {
   background-color: rgba(0, 0, 0, 0.5);
 }
+
+/* Notebook dataframe output */
+.md-typeset table.dataframe {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+}
+
+.md-typeset table.dataframe th,
+.md-typeset table.dataframe td {
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary

- Add site-wide CSS for pandas dataframe outputs in converted notebook tutorials.
- Keep wide dataframes inside the MkDocs content column with horizontal scrolling.
- Preserve numeric/table readability by preventing cell wrapping.

## Why

Wide pandas tables emitted by nbconvert render as raw `<table class="dataframe">` blocks. Without an overflow rule, they can extend beyond the tutorial content column and overlap the right-side table of contents.

## Validation

- Confirmed locally in the browser against `site/tutorials/sharp_wave_ripple_detection/`.
- Ran `uv run zensical build`; build completed successfully. Existing generated tutorial unresolved-link warnings remain unrelated to this CSS change.