### PR TITLE
Bump version for v0.2.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neuro-analysis-py"
-version = "0.0.2"
+version = "0.2.0"
 description = "Analysis of neuroelectrophysiology data in Python."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- Bump package version from `0.0.2` to `0.2.0` in `pyproject.toml`
- Prepare the repository for a `v0.2.0` release after the accumulated changes since `v0.1.0`

## Release rationale
Since `v0.1.0` on 2025-08-22, `main` has accumulated substantial new functionality and compatibility changes, including SWR detection work, LFP loader improvements, peri-event utilities, plotting helpers/styles, replay and assembly updates, HDF5 batch support, expanded docs/tutorials, Python 3.13 support, and Python 3.9 removal.

## Validation
- `ruff check .` passed locally
- `pytest` could not be meaningfully run locally because the available sandbox `pytest` points to Python 3.8, while the project now requires Python >=3.10; collection failed on unsupported-environment/dependency issues before testing the version bump

## After merge
- Confirm CI is green on supported Python versions
- Tag the merge commit as `v0.2.0`
- Publish a GitHub release using the PR range `v0.1.0...v0.2.0`