### PR TITLE
[codex] Handle all-NaN columns in zscore

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,6 +88,11 @@ neuro_py/
 - CI runs `ruff check .` and `pytest` on Python 3.10, 3.11, 3.12, and 3.13.
 - When running pytest locally, prefer a project environment with the package test dependencies installed so imports like `lazy_loader`, `nelpy`, and other runtime requirements resolve during collection.
 - If pytest fails before collection because unrelated third-party plugins auto-load from the active environment, rerun the same target with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` to isolate the repo's own tests.
+- On this Windows workspace, if the ambient Anaconda Python is too old or missing dependencies and `.venv`/`uv` reports cache or interpreter access issues, set the uv cache inside the repo and inject pytest for the run:
+  ```powershell
+  $env:UV_CACHE_DIR='D:\github\neuro_py\.uv-cache'
+  uv run --with pytest python -m pytest tests\util\test_util_array.py -q
+  ```
 
 Before finishing a change, run the narrowest relevant test subset first, then broader tests if needed. If you cannot run tests in the current environment, say so explicitly.
 

--- a/neuro_py/util/array.py
+++ b/neuro_py/util/array.py
@@ -347,6 +347,7 @@ def zscore_columns(df: pd.DataFrame, ddof: int = 0) -> pd.DataFrame:
     Notes
     -----
     - Columns with zero variance will result in NaN values.
+    - Columns that are entirely missing will remain NaN.
     - The input DataFrame is not modified.
 
     Examples
@@ -388,14 +389,18 @@ def zscore_columns(df: pd.DataFrame, ddof: int = 0) -> pd.DataFrame:
     1       NaN
     2       NaN
     """
-    numeric_cols = df.select_dtypes(include=[np.number]).columns
-    if not numeric_cols.equals(df.columns):
-        non_numeric = df.columns.difference(numeric_cols)
+    non_numeric = [
+        column
+        for idx, (column, dtype) in enumerate(zip(df.columns, df.dtypes))
+        if not pd.api.types.is_numeric_dtype(dtype) and not df.iloc[:, idx].isna().all()
+    ]
+    if non_numeric:
         raise TypeError(
             "zscore_columns expects all columns to be numeric; "
-            f"non-numeric columns found: {list(non_numeric)}"
+            f"non-numeric columns found: {non_numeric}"
         )
-    return (df - df.mean(axis=0)) / df.std(axis=0, ddof=ddof)
+    numeric_df = df.astype(float)
+    return (numeric_df - numeric_df.mean(axis=0)) / numeric_df.std(axis=0, ddof=ddof)
 
 
 def smooth_peth(

--- a/tests/util/test_util_array.py
+++ b/tests/util/test_util_array.py
@@ -402,6 +402,32 @@ def test_zscore_zero_variance_column():
     assert np.isclose(z["varying"].mean(), 0.0)
 
 
+def test_zscore_all_nan_columns_are_preserved():
+    """All-NaN columns should remain NaN instead of failing validation."""
+    df = pd.DataFrame(
+        {
+            0: pd.Series([np.nan, np.nan, np.nan], dtype=object),
+            1: pd.Series([np.nan, np.nan, np.nan], dtype=object),
+            2: [1.0, 2.0, 3.0],
+        }
+    )
+
+    z = zscore_columns(df, ddof=0)
+
+    assert z[0].isna().all()
+    assert z[1].isna().all()
+    assert np.isclose(z[2].mean(), 0.0)
+    assert np.isclose(z[2].std(ddof=0), 1.0)
+
+
+def test_zscore_non_numeric_columns_raise():
+    """Non-numeric columns with data should still raise."""
+    df = pd.DataFrame({"numeric": [1.0, 2.0, 3.0], "label": ["a", "b", "c"]})
+
+    with pytest.raises(TypeError, match="non-numeric columns found: \\['label'\\]"):
+        zscore_columns(df)
+
+
 class TestSmoothPeth:
     def test_numpy_array_matches_gaussian_filter(self):
         """NumPy path should match pandas Gaussian rolling reference."""


### PR DESCRIPTION
## Summary

- Allow `zscore_columns` to preserve columns that are entirely missing instead of rejecting them as non-numeric.
- Keep true non-numeric columns rejected with the existing `TypeError` behavior.
- Add regression coverage for object-dtype all-NaN columns and document the Windows `uv` pytest invocation that worked in this workspace.

## Root Cause

`zscore_columns` used `select_dtypes(include=[np.number])` to validate columns. In some DataFrame constructions, all-NaN columns can have `object` dtype, so they were reported as non-numeric even though z-scoring should naturally leave them as NaN.

## Validation

- `ruff check neuro_py\util\array.py tests\util\test_util_array.py`
- `$env:UV_CACHE_DIR='D:\github\neuro_py\.uv-cache'; uv run --with pytest python -m pytest tests\util\test_util_array.py -q` (`49 passed`)