### PR TITLE
Support single-epoch dicts in NodePicker

### DIFF
--- a/neuro_py/behavior/linearization.py
+++ b/neuro_py/behavior/linearization.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import sys
+from collections.abc import MutableMapping, Sequence
 from typing import Any, List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
@@ -2122,13 +2123,21 @@ class NodePicker:
         dict
             The updated behavior data dictionary.
         """
-        def get_epoch_entry(epoch_index: int) -> dict:
+        def validate_epoch_entry(epoch_entry: object, epoch_index: int) -> MutableMapping:
+            if not isinstance(epoch_entry, MutableMapping):
+                raise TypeError(
+                    "behavior['epochs'] entries must be mutable mapping types, "
+                    f"got {type(epoch_entry).__name__} at index {epoch_index}"
+                )
+            return epoch_entry
+
+        def get_epoch_entry(epoch_index: int) -> MutableMapping:
             behavior_epochs = data["behavior"].get("epochs")
 
             if behavior_epochs is None:
                 raise KeyError("behavior['epochs'] is missing from the behavior file")
 
-            if isinstance(behavior_epochs, dict):
+            if isinstance(behavior_epochs, MutableMapping):
                 if epoch_index != 0:
                     raise IndexError(
                         f"behavior['epochs'] contains a single epoch, cannot access index {epoch_index}"
@@ -2136,17 +2145,17 @@ class NodePicker:
                 return behavior_epochs
 
             if isinstance(behavior_epochs, np.ndarray):
-                if behavior_epochs.ndim == 0:
-                    epoch_entry = behavior_epochs.item()
-                else:
-                    epoch_entry = behavior_epochs[epoch_index]
-                if not isinstance(epoch_entry, dict):
-                    raise TypeError(
-                        "behavior['epochs'] entries must be dict-like after loading"
-                    )
-                return epoch_entry
+                behavior_epochs = behavior_epochs.item() if behavior_epochs.ndim == 0 else behavior_epochs
 
-            return behavior_epochs[epoch_index]
+            if isinstance(behavior_epochs, Sequence) and not isinstance(
+                behavior_epochs, (str, bytes, bytearray)
+            ):
+                return validate_epoch_entry(behavior_epochs[epoch_index], epoch_index)
+
+            raise TypeError(
+                "behavior['epochs'] must be a mutable mapping, numpy.ndarray, or sequence "
+                f"of mutable mappings, got {type(behavior_epochs).__name__}"
+            )
 
         if self.epoch is None and self.interval is None:
             # load epochs

--- a/neuro_py/behavior/linearization.py
+++ b/neuro_py/behavior/linearization.py
@@ -2122,6 +2122,32 @@ class NodePicker:
         dict
             The updated behavior data dictionary.
         """
+        def get_epoch_entry(epoch_index: int) -> dict:
+            behavior_epochs = data["behavior"].get("epochs")
+
+            if behavior_epochs is None:
+                raise KeyError("behavior['epochs'] is missing from the behavior file")
+
+            if isinstance(behavior_epochs, dict):
+                if epoch_index != 0:
+                    raise IndexError(
+                        f"behavior['epochs'] contains a single epoch, cannot access index {epoch_index}"
+                    )
+                return behavior_epochs
+
+            if isinstance(behavior_epochs, np.ndarray):
+                if behavior_epochs.ndim == 0:
+                    epoch_entry = behavior_epochs.item()
+                else:
+                    epoch_entry = behavior_epochs[epoch_index]
+                if not isinstance(epoch_entry, dict):
+                    raise TypeError(
+                        "behavior['epochs'] entries must be dict-like after loading"
+                    )
+                return epoch_entry
+
+            return behavior_epochs[epoch_index]
+
         if self.epoch is None and self.interval is None:
             # load epochs
             epochs = load_epoch(self.basepath)
@@ -2130,14 +2156,13 @@ class NodePicker:
                 # locate index for given epoch
                 idx = behave_df.time.between(ep.startTime, ep.stopTime)
                 # if linearized is not all nan, add nodes and edges
-                if not all(np.isnan(behave_df[idx].linearized)) & (
-                    behave_df[idx].shape[0] != 0
+                if behave_df[idx].shape[0] != 0 and not np.all(
+                    np.isnan(behave_df[idx].linearized)
                 ):
                     # adding nodes and edges
-                    data["behavior"]["epochs"][epoch_i]["node_positions"] = (
-                        self.node_positions
-                    )
-                    data["behavior"]["epochs"][epoch_i]["edges"] = self.edges
+                    epoch_entry = get_epoch_entry(epoch_i)
+                    epoch_entry["node_positions"] = self.node_positions
+                    epoch_entry["edges"] = self.edges
         elif self.interval is not None:
             # if interval was used, add nodes and edges just the epochs within that interval
             epochs = load_epoch(self.basepath)
@@ -2149,16 +2174,14 @@ class NodePicker:
 
                 # if overlap is greater than 1 second, add nodes and edges
                 if overlap > 1:
-                    data["behavior"]["epochs"][epoch_i]["node_positions"] = (
-                        self.node_positions
-                    )
-                    data["behavior"]["epochs"][epoch_i]["edges"] = self.edges
+                    epoch_entry = get_epoch_entry(epoch_i)
+                    epoch_entry["node_positions"] = self.node_positions
+                    epoch_entry["edges"] = self.edges
         else:
             # if epoch was used, add nodes and edges just that that epoch
-            data["behavior"]["epochs"][self.epoch]["node_positions"] = (
-                self.node_positions
-            )
-            data["behavior"]["epochs"][self.epoch]["edges"] = self.edges
+            epoch_entry = get_epoch_entry(self.epoch)
+            epoch_entry["node_positions"] = self.node_positions
+            epoch_entry["edges"] = self.edges
 
         return data
 

--- a/tests/behavior/test_linearization.py
+++ b/tests/behavior/test_linearization.py
@@ -533,6 +533,45 @@ class TestNodePicker:
             expected = [(0, 0), (2, 0)]
             assert picker._nodes == expected
 
+    @patch("neuro_py.behavior.linearization.load_epoch")
+    def test_save_nodes_edges_to_behavior_single_epoch_dict(self, mock_load_epoch):
+        """Regression test for behavior files where epochs loads as a single dict."""
+        with patch("matplotlib.pyplot.gca") as mock_gca:
+            mock_ax = Mock()
+            mock_gca.return_value = mock_ax
+
+            picker = NodePicker(basepath="test_basepath")
+            picker._nodes = [(0, 0), (1, 0)]
+            picker.edges = [[0, 1]]
+
+            behave_df = pd.DataFrame(
+                {
+                    "time": [0.5, 1.0, 1.5],
+                    "linearized": [0.0, 1.0, 2.0],
+                }
+            )
+            mock_load_epoch.return_value = pd.DataFrame(
+                [{"startTime": 0.0, "stopTime": 2.0}]
+            )
+
+            data = {
+                "behavior": {
+                    "epochs": {
+                        "name": "y_maze",
+                        "startTime": 0.0,
+                        "stopTime": 2.0,
+                    }
+                }
+            }
+
+            result = picker.save_nodes_edges_to_behavior(data, behave_df)
+
+            np.testing.assert_array_equal(
+                result["behavior"]["epochs"]["node_positions"],
+                np.array([[0, 0], [1, 0]]),
+            )
+            assert result["behavior"]["epochs"]["edges"] == [[0, 1]]
+
     @patch("neuro_py.behavior.linearization.load_animal_behavior")
     @patch("neuro_py.behavior.linearization.load_epoch")
     @patch("neuro_py.behavior.linearization.loadmat")

--- a/tests/behavior/test_linearization.py
+++ b/tests/behavior/test_linearization.py
@@ -572,6 +572,70 @@ class TestNodePicker:
             )
             assert result["behavior"]["epochs"]["edges"] == [[0, 1]]
 
+    @patch("neuro_py.behavior.linearization.load_epoch")
+    def test_save_nodes_edges_to_behavior_zero_dim_epoch_array_list(self, mock_load_epoch):
+        """Regression test for zero-dimensional epoch arrays wrapping a list."""
+        with patch("matplotlib.pyplot.gca") as mock_gca:
+            mock_ax = Mock()
+            mock_gca.return_value = mock_ax
+
+            picker = NodePicker(basepath="test_basepath")
+            picker._nodes = [(0, 0), (1, 0)]
+            picker.edges = [[0, 1]]
+
+            behave_df = pd.DataFrame(
+                {
+                    "time": [0.5, 1.0, 1.5],
+                    "linearized": [0.0, 1.0, 2.0],
+                }
+            )
+            mock_load_epoch.return_value = pd.DataFrame(
+                [{"startTime": 0.0, "stopTime": 2.0}]
+            )
+
+            epochs_array = np.empty((), dtype=object)
+            epochs_array[()] = [
+                {
+                    "name": "y_maze",
+                    "startTime": 0.0,
+                    "stopTime": 2.0,
+                }
+            ]
+            data = {"behavior": {"epochs": epochs_array}}
+
+            result = picker.save_nodes_edges_to_behavior(data, behave_df)
+            epoch_entry = result["behavior"]["epochs"].item()[0]
+
+            np.testing.assert_array_equal(
+                epoch_entry["node_positions"],
+                np.array([[0, 0], [1, 0]]),
+            )
+            assert epoch_entry["edges"] == [[0, 1]]
+
+    def test_save_nodes_edges_to_behavior_invalid_epochs_type(self):
+        """Raise a clear error when behavior['epochs'] has an invalid type."""
+        with patch("matplotlib.pyplot.gca") as mock_gca:
+            mock_ax = Mock()
+            mock_gca.return_value = mock_ax
+
+            picker = NodePicker(basepath="test_basepath", epoch=0)
+            picker._nodes = [(0, 0), (1, 0)]
+            picker.edges = [[0, 1]]
+
+            behave_df = pd.DataFrame(
+                {
+                    "time": [0.5, 1.0, 1.5],
+                    "linearized": [0.0, 1.0, 2.0],
+                }
+            )
+            data = {"behavior": {"epochs": 1}}
+
+            with pytest.raises(
+                TypeError,
+                match=r"behavior\['epochs'\].*got int",
+            ):
+                picker.save_nodes_edges_to_behavior(data, behave_df)
+
     @patch("neuro_py.behavior.linearization.load_animal_behavior")
     @patch("neuro_py.behavior.linearization.load_epoch")
     @patch("neuro_py.behavior.linearization.loadmat")


### PR DESCRIPTION
Add get_epoch_entry helper to robustly handle behavior['epochs'] when it's a single dict, a numpy scalar/array, or a sequence, and raise clear errors for missing or invalid types. Replace direct indexing into data['behavior']['epochs'] with the helper so node_positions and edges are written safely. Also adjust the empty-check/np.isnan logic to use behave_df.shape and np.all to avoid warnings. Add a regression test (test_save_nodes_edges_to_behavior_single_epoch_dict) to cover the single-epoch-dict case.