### PR TITLE
[codex] Make deep-learning decoders optional via dl extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,39 @@ jobs:
       - name: Run tests
         run: |
           python tools/run_pytest.py
+
+  base-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+          key: ${{ runner.os }}-base-smoke-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-base-smoke-
+
+      - name: Install base dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools setuptools-scm
+          pip install -e .
+          pip install pytest
+
+      - name: Smoke import base package
+        run: |
+          python -c "import neuro_py; import neuro_py.ensemble.decoding; from neuro_py.ensemble.decoding.bayesian import decode"
+
+      - name: Run plain pytest smoke checks
+        run: |
+          pytest tests/util/test_lazy_loading.py tests/ensemble/decoding/test_optional_dl_dependencies.py -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools setuptools-scm
-          pip install -e .[all]
+          pip install .[all]
           pip install pytest 
           
       - name: Install ruff for linting
@@ -78,7 +78,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools setuptools-scm
-          pip install -e .
+          pip install .
           pip install pytest
 
       - name: Smoke import base package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools setuptools-scm
-          pip install .[all]
+          pip install -e .[all]
           pip install pytest 
           
       - name: Install ruff for linting
@@ -51,4 +51,4 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest
+          python tools/run_pytest.py

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ For ease of use, this package uses `nelpy` core data objects. See [nelpy](https:
 
 ## Testing
 
+The canonical repo test entrypoint is:
+
 ```bash
 python tools/run_pytest.py
 ```
@@ -68,6 +70,8 @@ This wrapper sets a few local defaults that make editable `nelpy` installs more 
 - `NUMBA_DISABLE_JIT=1`
 - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`
 - `MPLBACKEND=Agg`
+
+CI also runs a lightweight plain-`pytest` smoke check against the base install so we still catch issues outside the wrapper path.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Overview
 ========
 `neuro_py` is a Python package for analysis of neuroelectrophysiology data. It is built on top of the [nelpy](https://github.com/nelpy/nelpy) package, which provides core data objects. `neuro_py` provides a set of functions for analysis of freely moving electrophysiology, including behavior tracking utilities, neural ensemble detection, peri-event analyses, robust batch analysis tools, and more. 
 
-Tutorials are [here](https://github.com/ryanharvey1/neuro_py/tree/main/tutorials) and more will be added. 
+Tutorials are [here](https://github.com/ryanharvey1/neuro_py/tree/main/tutorials) and more will be added.
+The decoding tutorial and torch/lightning-backed decoders require the optional `dl` extra.
 
 
 ## Installation
@@ -25,6 +26,12 @@ Tutorials are [here](https://github.com/ryanharvey1/neuro_py/tree/main/tutorials
 git clone
 cd neuro_py
 pip install -e .
+```
+
+For the optional deep-learning decoders, install the `dl` extra:
+
+```bash
+pip install -e .[dl]
 ```
 
 To sync the `nelpy` dependency to latest version, use following instead,

--- a/README.md
+++ b/README.md
@@ -53,23 +53,25 @@ For ease of use, this package uses `nelpy` core data objects. See [nelpy](https:
 
 ## Testing
 
-The canonical repo test entrypoint is:
+Use plain `pytest` for normal development and CI-like local runs:
+
+```bash
+pytest
+```
+
+To run a narrow target:
+
+```bash
+pytest tests/detectors/test_sharp_wave_ripple.py -q
+```
+
+If your local environment auto-loads unrelated third-party pytest plugins, use the wrapper to isolate the repo's own test environment:
 
 ```bash
 python tools/run_pytest.py
 ```
 
-To run a narrow target, pass the usual `pytest` arguments through:
-
-```bash
-python tools/run_pytest.py tests/detectors/test_sharp_wave_ripple.py -q
-```
-
-This wrapper sets a few local defaults that make editable `nelpy` installs more reliable in development environments:
-
-- `NUMBA_DISABLE_JIT=1`
-- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`
-- `MPLBACKEND=Agg`
+This wrapper only sets `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`. Numba JIT and matplotlib backend behavior are exercised by the tests themselves.
 
 CI also runs a lightweight plain-`pytest` smoke check against the base install so we still catch issues outside the wrapper path.
 

--- a/neuro_py/ensemble/decoding/__init__.py
+++ b/neuro_py/ensemble/decoding/__init__.py
@@ -1,3 +1,20 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from ...util._dependencies import _check_dependency
+from .bayesian import decode
+from .pipeline import (
+    format_trial_segs_nsv,
+    get_spikes_with_history,
+    normalize_format_trial_segs,
+    normalize_labels,
+    shuffle_nsv_intrialsegs,
+    zscore_trial_segs,
+)
+from .preprocess import partition_indices, partition_sets, split_data
+
 __all__ = [
     "MLP",
     "LSTM",
@@ -22,28 +39,40 @@ __all__ = [
     "decode",
 ]
 
-from .bayesian import decode
-from .lstm import LSTM
-from .m2mlstm import M2MLSTM
-from .mlp import MLP
-from .pipeline import (
-    create_model,
-    evaluate_model,
-    format_trial_segs_nsv,
-    get_spikes_with_history,
-    minibatchify,
-    normalize_format_trial_segs,
-    normalize_labels,
-    predict_models_folds,
-    preprocess_data,
-    seed_worker,
-    shuffle_nsv_intrialsegs,
-    train_model,
-    zscore_trial_segs,
-)
-from .preprocess import (
-    partition_indices,
-    partition_sets,
-    split_data,
-)
-from .transformer import NDT
+_DL_EXPORTS = {
+    "MLP": (".mlp", "MLP"),
+    "LSTM": (".lstm", "LSTM"),
+    "M2MLSTM": (".m2mlstm", "M2MLSTM"),
+    "NDT": (".transformer", "NDT"),
+    "seed_worker": (".pipeline", "seed_worker"),
+    "minibatchify": (".pipeline", "minibatchify"),
+    "create_model": (".pipeline", "create_model"),
+    "preprocess_data": (".pipeline", "preprocess_data"),
+    "evaluate_model": (".pipeline", "evaluate_model"),
+    "train_model": (".pipeline", "train_model"),
+    "predict_models_folds": (".pipeline", "predict_models_folds"),
+}
+_TENSORBOARD_EXPORTS = {"train_model"}
+
+
+def _load_dl_export(name: str) -> Any:
+    _check_dependency("torch", "dl")
+    _check_dependency("lightning", "dl")
+    module_name, attr_name = _DL_EXPORTS[name]
+    if name in _TENSORBOARD_EXPORTS:
+        _check_dependency("tensorboard", "dl")
+
+    module = importlib.import_module(module_name, __name__)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DL_EXPORTS:
+        return _load_dl_export(name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/neuro_py/ensemble/decoding/lstm.py
+++ b/neuro_py/ensemble/decoding/lstm.py
@@ -1,5 +1,10 @@
 from typing import Dict, List, Optional, Tuple
 
+from ...util._dependencies import _check_dependency
+
+_check_dependency("torch", "dl")
+_check_dependency("lightning", "dl")
+
 import lightning as L
 import torch
 import torch.nn.functional as F

--- a/neuro_py/ensemble/decoding/m2mlstm.py
+++ b/neuro_py/ensemble/decoding/m2mlstm.py
@@ -1,5 +1,10 @@
 from typing import Dict, List, Optional, Tuple
 
+from ...util._dependencies import _check_dependency
+
+_check_dependency("torch", "dl")
+_check_dependency("lightning", "dl")
+
 import lightning as L
 import numpy as np
 import torch

--- a/neuro_py/ensemble/decoding/mlp.py
+++ b/neuro_py/ensemble/decoding/mlp.py
@@ -1,5 +1,10 @@
 from typing import Dict, List, Optional, Union
 
+from ...util._dependencies import _check_dependency
+
+_check_dependency("torch", "dl")
+_check_dependency("lightning", "dl")
+
 import lightning as L
 import torch
 from torch import nn

--- a/neuro_py/ensemble/decoding/pipeline.py
+++ b/neuro_py/ensemble/decoding/pipeline.py
@@ -36,6 +36,9 @@ def _get_decoder(name: str) -> Any:
         "M2MLSTM": M2MLSTM,
         "NDT": NDT,
     }
+    if name not in decoders:
+        supported = ", ".join(sorted(decoders))
+        raise ValueError(f"Unknown decoder '{name}'. Supported decoders: {supported}")
     return decoders[name]
 
 

--- a/neuro_py/ensemble/decoding/pipeline.py
+++ b/neuro_py/ensemble/decoding/pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import os
 import random
@@ -5,18 +7,36 @@ import zlib
 from typing import Any, Dict, List, Optional, Tuple
 
 import bottleneck as bn
-import lightning.pytorch as pl
 import numpy as np
 import pandas as pd
 import sklearn
 import sklearn.preprocessing
-import torch
 from numpy.typing import NDArray
 
-from .lstm import LSTM  # noqa
-from .m2mlstm import M2MLSTM, NSVDataset  # noqa
-from .mlp import MLP  # noqa
-from .transformer import NDT  # noqa
+from ...util._dependencies import _check_dependency
+
+
+def _check_dl_dependencies(include_tensorboard: bool = False) -> None:
+    _check_dependency("torch", "dl")
+    _check_dependency("lightning", "dl")
+    if include_tensorboard:
+        _check_dependency("tensorboard", "dl")
+
+
+def _get_decoder(name: str) -> Any:
+    _check_dl_dependencies()
+    from .lstm import LSTM
+    from .m2mlstm import M2MLSTM
+    from .mlp import MLP
+    from .transformer import NDT
+
+    decoders = {
+        "MLP": MLP,
+        "LSTM": LSTM,
+        "M2MLSTM": M2MLSTM,
+        "NDT": NDT,
+    }
+    return decoders[name]
 
 
 def seed_worker(worker_id: int) -> None:
@@ -32,6 +52,9 @@ def seed_worker(worker_id: int) -> None:
     -----
     This function is used to ensure reproducibility when using multi-process data loading.
     """
+    _check_dl_dependencies()
+    import torch
+
     worker_seed = torch.initial_seed() % 2**32
     np.random.seed(worker_seed)
     random.seed(worker_seed)
@@ -407,6 +430,9 @@ def minibatchify(
     Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.utils.data.DataLoader]
         DataLoaders for training, validation, and testing.
     """
+    _check_dl_dependencies()
+    import torch
+
     g_seed = torch.Generator()
     g_seed.manual_seed(seed)
     if Xtrain.ndim == 2:  # handle object arrays
@@ -509,7 +535,7 @@ def create_model(hyperparams: Dict[str, Any]) -> Tuple[Any, pl.LightningModule]:
     Tuple[Any, pl.LightningModule]
         The decoder class and instantiated model.
     """
-    decoder = eval(f"{hyperparams['model']}")
+    decoder = _get_decoder(hyperparams["model"])
     model = decoder(**hyperparams["model_args"])
 
     if "LSTM" in hyperparams["model"]:
@@ -568,6 +594,9 @@ def preprocess_data(
     Tuple[Tuple[NDArray, NDArray, NDArray, NDArray, NDArray, NDArray], Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.utils.data.DataLoader], Dict[str, Any]]
         Preprocessed data, data loaders, and normalization parameters.
     """
+    _check_dl_dependencies()
+    import torch
+
     bins_before = hyperparams["bins_before"]
     bins_current = hyperparams["bins_current"]
     bins_after = hyperparams["bins_after"]
@@ -618,6 +647,8 @@ def preprocess_data(
         )
         hyperparams["model_args"]["in_dim"] = X_train.shape[-1]
     else:
+        from .m2mlstm import NSVDataset
+
         if is_2D:
             nsv_train, bv_train = [nsv_train], [bv_train]
             nsv_val, bv_val = [nsv_val], [bv_val]
@@ -752,6 +783,9 @@ def evaluate_model(
     Tuple[Dict[str, float], NDArray]
         Evaluation metrics and model predictions.
     """
+    _check_dl_dependencies()
+    import torch
+
     if hyperparams["model"] in ("M2MLSTM", "NDT"):
         out_dim = hyperparams["model_args"]["out_dim"]
         with torch.no_grad():
@@ -920,6 +954,9 @@ def train_model(
         'cpu'.
     - `seed`: int, the random seed for reproducibility.
     """
+    _check_dl_dependencies(include_tensorboard=True)
+    import lightning.pytorch as pl
+
     ohe = sklearn.preprocessing.OneHotEncoder()
     bv_preds_folds = []
     bv_models_folds = []

--- a/neuro_py/ensemble/decoding/transformer.py
+++ b/neuro_py/ensemble/decoding/transformer.py
@@ -1,5 +1,10 @@
 from typing import Dict, Optional, Tuple
 
+from ...util._dependencies import _check_dependency
+
+_check_dependency("torch", "dl")
+_check_dependency("lightning", "dl")
+
 import lightning as L
 import numpy as np
 import torch

--- a/neuro_py/util/_dependencies.py
+++ b/neuro_py/util/_dependencies.py
@@ -11,8 +11,10 @@ def _check_dependency(module_name: str, extra: str) -> None:
     """
     try:
         __import__(module_name)
-    except ImportError:
+    except ModuleNotFoundError as exc:
+        if exc.name != module_name:
+            raise
         raise ImportError(
             f"{module_name} is not installed. Please install it to use this function. "
             f"Run: pip install -e .[{extra}]"
-        )
+        ) from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ dependencies = [
     "lazy-loader>=0.4",
     "PyWavelets>=1.6.0",
     "Bottleneck>=1.4.2",
-    "tensorboard>=2.18.0",
-    "lightning>=2.4.0",
     "h5py>=3.13.0",
     "decorator>=4.4.2",
     # Conditional dependency for Python < 3.11
@@ -44,6 +42,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# For deep-learning decoders and training pipelines
+dl = [
+    "lightning>=2.4.0",
+    "tensorboard>=2.18.0"
+]
 # For current source density (CSD) analysis
 csd = [
     "elephant>=1.1.0",
@@ -59,6 +62,8 @@ docs = [
 ]
 # An "all" group that combines all optional groups
 all = [
+    "lightning>=2.4.0",
+    "tensorboard>=2.18.0",
     "elephant>=1.1.0",
     "neo>=0.13.3",
     "quantities>=0.15.0",

--- a/tests/ensemble/decoding/test_bayesian_decode.py
+++ b/tests/ensemble/decoding/test_bayesian_decode.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from numba.core.errors import TypingError
 
 from neuro_py.ensemble.decoding.bayesian import decode
 
@@ -51,13 +50,17 @@ def test_invalid_input_shapes():
         decode(ct, tc, occupancy, bin_size_s)
 
 
-def test_non_numeric_input_values():
-    ct = np.random.rand(10, 5)
-    tc = np.random.rand(3, 3, 5)
-    occupancy = np.random.rand(3, 3)
-    bin_size_s = "a"
-    with pytest.raises((TypingError, TypeError)):
-        decode(ct, tc, occupancy, bin_size_s)
+def test_decode_jit_compiles_and_repeated_calls_are_stable():
+    rng = np.random.default_rng(0)
+    ct = rng.random((10, 5))
+    tc = rng.random((3, 3, 5))
+    occupancy = rng.random((3, 3))
+
+    first = decode(ct, tc, occupancy, 0.1)
+    second = decode(ct, tc, occupancy, 0.1)
+
+    np.testing.assert_allclose(first, second)
+    np.testing.assert_allclose(first.sum(axis=(1, 2)), np.ones(first.shape[0]))
 
 
 def test_1d_input():

--- a/tests/ensemble/decoding/test_bayesian_decode.py
+++ b/tests/ensemble/decoding/test_bayesian_decode.py
@@ -56,7 +56,7 @@ def test_non_numeric_input_values():
     tc = np.random.rand(3, 3, 5)
     occupancy = np.random.rand(3, 3)
     bin_size_s = "a"
-    with pytest.raises(TypingError):
+    with pytest.raises((TypingError, TypeError)):
         decode(ct, tc, occupancy, bin_size_s)
 
 

--- a/tests/ensemble/decoding/test_bayesian_decode.py
+++ b/tests/ensemble/decoding/test_bayesian_decode.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numba.core.errors import TypingError
 
 from neuro_py.ensemble.decoding.bayesian import decode
 
@@ -61,6 +62,15 @@ def test_decode_jit_compiles_and_repeated_calls_are_stable():
 
     np.testing.assert_allclose(first, second)
     np.testing.assert_allclose(first.sum(axis=(1, 2)), np.ones(first.shape[0]))
+
+
+def test_non_numeric_input_values():
+    ct = np.random.rand(10, 5)
+    tc = np.random.rand(3, 3, 5)
+    occupancy = np.random.rand(3, 3)
+
+    with pytest.raises(TypingError):
+        decode(ct, tc, occupancy, "a")
 
 
 def test_1d_input():

--- a/tests/ensemble/decoding/test_dnn_decoders.py
+++ b/tests/ensemble/decoding/test_dnn_decoders.py
@@ -3,6 +3,12 @@ import unittest
 
 import numpy as np
 import pandas as pd
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("lightning")
+pytest.importorskip("tensorboard")
+
 import torch
 import torch.nn.functional as F
 from torch import nn

--- a/tests/ensemble/decoding/test_optional_dl_dependencies.py
+++ b/tests/ensemble/decoding/test_optional_dl_dependencies.py
@@ -1,0 +1,47 @@
+import builtins
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+DL_MODULES = {"torch", "lightning", "tensorboard"}
+_ORIGINAL_IMPORT = builtins.__import__
+
+
+def _clear_neuro_py_modules() -> None:
+    for module in list(sys.modules):
+        if module.startswith("neuro_py"):
+            sys.modules.pop(module)
+
+
+def _mocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+    root_name = name.split(".")[0]
+    if root_name in DL_MODULES:
+        raise ImportError(f"{root_name} intentionally unavailable during test")
+    return _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)
+
+
+def test_decoding_imports_without_dl_dependencies() -> None:
+    _clear_neuro_py_modules()
+
+    with patch("builtins.__import__", side_effect=_mocked_import):
+        neuro_py = importlib.import_module("neuro_py")
+        ensemble = importlib.import_module("neuro_py.ensemble")
+        decoding = importlib.import_module("neuro_py.ensemble.decoding")
+        bayesian = importlib.import_module("neuro_py.ensemble.decoding.bayesian")
+
+    assert neuro_py is not None
+    assert ensemble is not None
+    assert decoding is not None
+    assert bayesian.decode is not None
+
+
+def test_dl_entrypoint_requires_dl_extra() -> None:
+    _clear_neuro_py_modules()
+
+    with patch("builtins.__import__", side_effect=_mocked_import):
+        decoding = importlib.import_module("neuro_py.ensemble.decoding")
+        with pytest.raises(ImportError, match=r"\[dl\]"):
+            decoding.MLP

--- a/tests/ensemble/decoding/test_optional_dl_dependencies.py
+++ b/tests/ensemble/decoding/test_optional_dl_dependencies.py
@@ -20,7 +20,9 @@ def _clear_neuro_py_modules() -> None:
 def _mocked_import(name, globals=None, locals=None, fromlist=(), level=0):
     root_name = name.split(".")[0]
     if root_name in DL_MODULES:
-        raise ImportError(f"{root_name} intentionally unavailable during test")
+        raise ModuleNotFoundError(
+            f"{root_name} intentionally unavailable during test", name=root_name
+        )
     return _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)
 
 

--- a/tests/ensemble/decoding/test_optional_dl_dependencies.py
+++ b/tests/ensemble/decoding/test_optional_dl_dependencies.py
@@ -1,6 +1,7 @@
 import builtins
 import importlib
 import sys
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
@@ -23,14 +24,28 @@ def _mocked_import(name, globals=None, locals=None, fromlist=(), level=0):
     return _ORIGINAL_IMPORT(name, globals, locals, fromlist, level)
 
 
-def test_decoding_imports_without_dl_dependencies() -> None:
+@contextmanager
+def _isolated_neuro_py_import_state():
+    original_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name.startswith("neuro_py")
+    }
     _clear_neuro_py_modules()
+    try:
+        yield
+    finally:
+        _clear_neuro_py_modules()
+        sys.modules.update(original_modules)
 
-    with patch("builtins.__import__", side_effect=_mocked_import):
-        neuro_py = importlib.import_module("neuro_py")
-        ensemble = importlib.import_module("neuro_py.ensemble")
-        decoding = importlib.import_module("neuro_py.ensemble.decoding")
-        bayesian = importlib.import_module("neuro_py.ensemble.decoding.bayesian")
+
+def test_decoding_imports_without_dl_dependencies() -> None:
+    with _isolated_neuro_py_import_state():
+        with patch("builtins.__import__", side_effect=_mocked_import):
+            neuro_py = importlib.import_module("neuro_py")
+            ensemble = importlib.import_module("neuro_py.ensemble")
+            decoding = importlib.import_module("neuro_py.ensemble.decoding")
+            bayesian = importlib.import_module("neuro_py.ensemble.decoding.bayesian")
 
     assert neuro_py is not None
     assert ensemble is not None
@@ -39,9 +54,8 @@ def test_decoding_imports_without_dl_dependencies() -> None:
 
 
 def test_dl_entrypoint_requires_dl_extra() -> None:
-    _clear_neuro_py_modules()
-
-    with patch("builtins.__import__", side_effect=_mocked_import):
-        decoding = importlib.import_module("neuro_py.ensemble.decoding")
-        with pytest.raises(ImportError, match=r"\[dl\]"):
-            decoding.MLP
+    with _isolated_neuro_py_import_state():
+        with patch("builtins.__import__", side_effect=_mocked_import):
+            decoding = importlib.import_module("neuro_py.ensemble.decoding")
+            with pytest.raises(ImportError, match=r"\[dl\]"):
+                decoding.MLP

--- a/tests/ensemble/decoding/test_pipeline_dependency_guards.py
+++ b/tests/ensemble/decoding/test_pipeline_dependency_guards.py
@@ -1,0 +1,11 @@
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("lightning")
+
+from neuro_py.ensemble.decoding.pipeline import _get_decoder
+
+
+def test_get_decoder_invalid_name_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="Unknown decoder 'BAD'"):
+        _get_decoder("BAD")

--- a/tests/plotting/test_replay_plotting.py
+++ b/tests/plotting/test_replay_plotting.py
@@ -1,13 +1,12 @@
 import warnings
 
 import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
 from neuro_py.plotting.replay import make_replay, plot_2d_replay
-
-matplotlib.use("Agg")
 
 
 def test_plot_2d_replay_returns_fig_ax_and_stable_image_count():

--- a/tests/process/test_correlations_coverage.py
+++ b/tests/process/test_correlations_coverage.py
@@ -5,21 +5,29 @@ Tests coverage for compute_AutoCorrs and pairwise_cross_corr.
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from neuro_py.process.correlations import compute_AutoCorrs, pairwise_cross_corr
 from neuro_py.process.peri_event import crossCorr
 
 
-@pytest.fixture(scope="module", autouse=True)
-def prewarm_jit():
-    """Pre-warm the JIT compiler with proper types to avoid typing issues during tests."""
-    prewarm_t1 = np.array([0.1, 0.2], dtype=np.float64)
-    prewarm_t2 = np.array([0.15, 0.25], dtype=np.float64)
-    try:
-        crossCorr(prewarm_t1, prewarm_t2, 0.01, 10)
-    except Exception as e:
-        pytest.fail(f"JIT compilation failed during pre-warm: {e}")
+def test_crosscorr_jit_compiles_and_returns_expected_shape():
+    t1 = np.array([0.1, 0.2], dtype=np.float64)
+    t2 = np.array([0.15, 0.25], dtype=np.float64)
+
+    result = crossCorr(t1, t2, 0.01, 10)
+
+    assert result.shape == (11,)
+    assert np.all(result >= 0)
+
+
+def test_crosscorr_repeated_calls_are_stable():
+    t1 = np.array([0.1, 0.2, 0.3], dtype=np.float64)
+    t2 = np.array([0.15, 0.25, 0.35], dtype=np.float64)
+
+    first = crossCorr(t1, t2, 0.01, 50)
+    second = crossCorr(t1, t2, 0.01, 50)
+
+    np.testing.assert_allclose(first, second)
 
 
 class TestComputeAutoCorrs:

--- a/tests/util/test_check_dependency.py
+++ b/tests/util/test_check_dependency.py
@@ -19,3 +19,17 @@ def test_check_dependency_failure():
     extra_name = "test"
     with pytest.raises(ImportError, match=f"{non_existent_module} is not installed."):
         _check_dependency(non_existent_module, extra_name)
+
+
+def test_check_dependency_preserves_nested_import_errors(monkeypatch):
+    """Nested import failures inside a dependency should surface the original error."""
+
+    def _raise_nested_module_not_found(name, *args, **kwargs):
+        if name == "some_installed_module":
+            raise ModuleNotFoundError("missing nested import", name="nested_dependency")
+        return __import__(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _raise_nested_module_not_found)
+
+    with pytest.raises(ModuleNotFoundError, match="missing nested import"):
+        _check_dependency("some_installed_module", "test")

--- a/tools/run_pytest.py
+++ b/tools/run_pytest.py
@@ -1,4 +1,4 @@
-"""Run pytest with local defaults that make editable ``nelpy`` test runs reliable."""
+"""Run pytest with local defaults that isolate ambient third-party plugins."""
 
 from __future__ import annotations
 
@@ -10,9 +10,7 @@ import sys
 def main() -> int:
     """Invoke pytest with repository-friendly environment defaults."""
     env = os.environ.copy()
-    env.setdefault("NUMBA_DISABLE_JIT", "1")
     env.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
-    env.setdefault("MPLBACKEND", "Agg")
 
     command = [sys.executable, "-m", "pytest", *sys.argv[1:]]
     completed = subprocess.run(command, env=env, check=False)


### PR DESCRIPTION
## Summary
This PR addresses the first slice of Issue #131 by moving the deep-learning decoding stack behind an optional `dl` extra while keeping Bayesian decoding available in the default install.

## What Changed
- removed `lightning` and `tensorboard` from core dependencies and added a new `dl` optional dependency group
- kept `.[all]` installing the deep-learning stack so CI and full installs continue to exercise that path
- refactored `neuro_py.ensemble.decoding` so Bayesian decoding and non-DL helpers import without requiring torch
- added explicit dependency guards for torch/lightning-backed decoder modules and training functions with a `pip install -e .[dl]` hint
- added regression coverage for importing decoding without DL dependencies and updated DL tests to skip cleanly when the optional stack is absent
- documented the optional `dl` install path in the README

## Why
The root issue was that importing the deep-learning decoding surface forced large transitive installs through `lightning` and `tensorboard`, even for users who only need the core scientific analysis features.

## Validation
- `uv run --with pytest python -m pytest tests\ensemble\decoding\test_bayesian_decode.py tests\ensemble\decoding\test_optional_dl_dependencies.py -q`
- `uv run --with pytest python -m pytest tests\util\test_lazy_loading.py -q`
- `ruff check pyproject.toml neuro_py\ensemble\decoding\__init__.py neuro_py\ensemble\decoding\pipeline.py neuro_py\ensemble\decoding\mlp.py neuro_py\ensemble\decoding\lstm.py neuro_py\ensemble\decoding\m2mlstm.py neuro_py\ensemble\decoding\transformer.py README.md tests\ensemble\decoding\test_dnn_decoders.py tests\ensemble\decoding\test_optional_dl_dependencies.py`

## Notes
- This PR intentionally does not remove the deep-learning decoder implementations.
- Follow-up dependency cleanup from Issue #131 can address the remaining optional-dependency candidates separately.