### PR TITLE
Use session epochs for spike stability filtering

### DIFF
--- a/neuro_py/io/loading.py
+++ b/neuro_py/io/loading.py
@@ -2741,12 +2741,44 @@ def load_spikes(
         st = st[restrict_idx]
 
     if remove_unstable and len(st) > 0:
-        concatenated_spikes = np.concatenate([np.asarray(spikes) for spikes in st])
-        starts = np.arange(
-            concatenated_spikes.min(),
-            concatenated_spikes.max() - stable_interval_width,
-            stable_interval_width,
-        )
+        try:
+            epochs = load_epoch(basepath)
+        except (KeyError, TypeError):
+            # Some legacy session files do not define epochs.
+            epochs = pd.DataFrame()
+        if {"startTime", "stopTime"}.issubset(epochs.columns):
+            epoch_bounds = epochs[["startTime", "stopTime"]].apply(
+                pd.to_numeric, errors="coerce"
+            )
+            epoch_bounds = epoch_bounds.dropna()
+            epoch_bounds = epoch_bounds[
+                (epoch_bounds["stopTime"] > epoch_bounds["startTime"])
+                & np.isfinite(epoch_bounds).all(axis=1)
+            ]
+        else:
+            epoch_bounds = pd.DataFrame(columns=["startTime", "stopTime"])
+
+        if len(epoch_bounds) > 0:
+            # Build bins within, rather than between, session epochs so recording
+            # gaps excluded by the user cannot count as inactive time.
+            starts = np.concatenate(
+                [
+                    np.arange(
+                        start, stop - stable_interval_width, stable_interval_width
+                    )
+                    for start, stop in epoch_bounds[
+                        ["startTime", "stopTime"]
+                    ].to_numpy()
+                ]
+            )
+        else:
+            # Preserve the previous behavior for sessions without epoch metadata.
+            concatenated_spikes = np.concatenate([np.asarray(spikes) for spikes in st])
+            starts = np.arange(
+                concatenated_spikes.min(),
+                concatenated_spikes.max() - stable_interval_width,
+                stable_interval_width,
+            )
         stops = starts + stable_interval_width
 
         bst = npy.process.count_in_interval(st, starts, stops, "counts")

--- a/neuro_py/io/loading.py
+++ b/neuro_py/io/loading.py
@@ -2756,7 +2756,12 @@ def load_spikes(
                 & np.isfinite(epoch_bounds).all(axis=1)
             ]
         else:
-            epoch_bounds = pd.DataFrame(columns=["startTime", "stopTime"])
+            epoch_bounds = pd.DataFrame(
+                {
+                    "startTime": pd.Series(dtype=float),
+                    "stopTime": pd.Series(dtype=float),
+                }
+            )
 
         if len(epoch_bounds) > 0:
             # Build bins within, rather than between, session epochs so recording

--- a/tests/test_io/test_loading.py
+++ b/tests/test_io/test_loading.py
@@ -2075,6 +2075,72 @@ def test_load_spikes_filter_by_stable():
         assert len(metrics) == 1
 
 
+def test_load_spikes_stability_uses_session_epochs():
+    """Ignore recording gaps outside the session epochs when filtering units."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        basepath = os.path.join(temp_dir, "session_epochs")
+        basename = os.path.basename(basepath)
+
+        create_temp_mat_file(
+            basepath,
+            {
+                f"{basename}.session.mat": {
+                    "session": {
+                        "extracellular": {"sr": 20000},
+                        "epochs": [
+                            {"name": "pre", "startTime": 0.0, "stopTime": 12.0},
+                            {"name": "post", "startTime": 100.0, "stopTime": 112.0},
+                        ],
+                    }
+                },
+                f"{basename}.cell_metrics.cellinfo.mat": {
+                    "cell_metrics": {
+                        "UID": np.array([1, 2], dtype="object"),
+                        "putativeCellType": np.array(["Pyramidal", "Pyramidal"]),
+                        "brainRegion": np.array(["CA1", "CA1"]),
+                        "tags": {"Bad": np.array([])},
+                        "spikes": {
+                            "times": np.array(
+                                [
+                                    np.array(
+                                        [[1.0], [4.0], [7.0], [101.0], [104.0], [107.0]]
+                                    ),
+                                    np.array([[1.0]]),
+                                ],
+                                dtype="object",
+                            )
+                        },
+                        "waveforms": {"filt": np.array([[[1, 2]], [[3, 4]]])},
+                        "acg": {
+                            "wide": np.array([[1, 2], [3, 4]]),
+                            "narrow": np.array([[1, 2], [3, 4]]),
+                            "log10": np.array([[1, 2], [3, 4]]),
+                        },
+                        "general": {
+                            "basename": basename,
+                            "cellCount": 2,
+                            "animal": {
+                                "sex": "male",
+                                "species": "rat",
+                                "strain": "long-evans",
+                                "geneticLine": "WT",
+                            },
+                        },
+                    }
+                },
+            },
+        )
+
+        st, metrics = load_spikes(
+            basepath, remove_unstable=True, stable_interval_width=3
+        )
+
+        assert st is not None
+        assert metrics is not None
+        assert st.n_active == 1
+        assert metrics["UID"].tolist() == [1]
+
+
 def test_load_spikes_other_metric_length_mismatch():
     """Test error when other_metric and other_metric_value have different lengths."""
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- derive remove_unstable bins independently within the session epochs from load_epoch
- keep legacy spike-span binning when epoch metadata is unavailable
- add coverage for recording gaps between adjusted epochs

## Tests
- uv run --with pytest python -m pytest tests/test_io/test_loading.py -q
- uv run ruff check neuro_py/io/loading.py tests/test_io/test_loading.py