### PR TITLE
Install uv for docs Marimo export

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Install dependencies
         run: pip install .[docs]
       - name: Pre-build (generate reference, convert tutorials)


### PR DESCRIPTION
## Summary
- install uv in the docs workflow before the Marimo HTML-WASM export
- pin the setup action to the version documented by Astral

## Validation
- workflow change reviewed against the failed docs job: Marimo required uv but it was absent from PATH